### PR TITLE
Add davet2001 energy sankey card

### DIFF
--- a/plugin
+++ b/plugin
@@ -75,6 +75,7 @@
   "daredoes/linked-lovelace-ui",
   "DarkFox/rejseplanen-card",
   "DarkFox/rejseplanen-stog-card",
+  "davet2001/energy-sankey",
   "DavidFW1960/bom-weather-card",
   "DBa2016/power-usage-card-regex",
   "dbuezas/lovelace-plotly-graph-card",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [ ] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/davet2001/energy-sankey/releases/tag/v0.0.7
Link to successful HACS action (without the `ignore` key): https://github.com/davet2001/energy-sankey/actions/runs/11603264239
Link to successful hassfest action (if integration): N/A

Side note: I'm not sure why the diff has highlighted a change to the closing ']'. That was not intentional.
